### PR TITLE
Allow binding to work with F#

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-This is a C# binding for FUSE.
+This is a Mono/.NET binding for FUSE.
 
 Short HOWTO:
 

--- a/src/Mono.Fuse/Mono.Fuse/FileSystem.cs
+++ b/src/Mono.Fuse/Mono.Fuse/FileSystem.cs
@@ -692,7 +692,7 @@ namespace Mono.Fuse {
 			ops.destroy = _OnDestroy;
 			foreach (string method in operations.Keys) {
 				MethodInfo m = this.GetType().GetMethod (method, 
-						BindingFlags.NonPublic | BindingFlags.Instance);
+						BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
 				MethodInfo bm = m.GetBaseDefinition ();
 				if (m.DeclaringType == typeof(FileSystem) ||
 						bm == null || bm.DeclaringType != typeof(FileSystem))


### PR DESCRIPTION
F# doesn't require `override` members to keep the
same accessibility of the inherited method. This is
covered in section 8.5.3.2 of the CLI spec:

  "When a type defines a virtual method that
   overrides an inherited definition, the
   accessibility shall either be identical
   in the two definitions or the overriding
   definition shall permit more access than
   the original definition."

It's not only very common to do this
unintentionally when inheriting from FileSystem
class in a F# class, because placing no access
keyword in this language makes it public by
default, but it's actually the only thing that
can be done, because F# doesn't have a 'protected'
keyword, and doesn't allow accessibility
modifiers on overrides anyway (so all of them
get exposed as public).

Therefore the method FileSystem.GetOperations() is
now changed to not only filter through non-public
methods when initializing operations.

As this makes the binding work with F# and not only
C#, the wording of the README is also changed to not
only mention "C#".
