### PR TITLE
Switch to using mcs for building

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-06-08  Justin Needham <jneedhamspkt@gmail.com>
+	Migrate from gmcs to mcs for Mono 4.*
+	* configure.ac: gmcs --> mcs
+	* doc/en/Mono.Fuse/FileSystem.xml : gmcs --> mcs
+
 2008-04-01  Jonathan Pryor  <jonpryor@vt.edu>
 
 	* configure.in: Error if `mono' can't be found (not continue), and continue

--- a/configure.ac
+++ b/configure.ac
@@ -11,14 +11,14 @@ AM_PROG_LIBTOOL
 ASSEMBLY_VERSION=0.4.3.0
 
 AC_PATH_PROG(MONO, mono)
-AC_PATH_PROG(CSC, gmcs)
+AC_PATH_PROG(CSC, mcs)
 
 if test "x$MONO" = "x" ; then
 	AC_MSG_ERROR([Can't find "mono" in your PATH])
 fi
 
 if test "x$CSC" = "x" ; then
-  AC_MSG_ERROR([Can't find "gmcs" in your PATH])
+  AC_MSG_ERROR([Can't find "mcs" in your PATH])
 fi
 AC_SUBST(PATH)
 AC_SUBST(LD_LIBRARY_PATH)
@@ -91,7 +91,7 @@ class Test {
 	}
 }
 EOF
-if gmcs try-copy.cs -r:Mono.Posix.dll 2>/dev/null >/dev/null ; then
+if mcs try-copy.cs -r:Mono.Posix.dll 2>/dev/null >/dev/null ; then
 	AC_MSG_RESULT([yes])
 	HAVE_MONO_UNIX_NATIVE_COPY_FUNCS=1
 else
@@ -112,7 +112,7 @@ class Test {
 	}
 }
 EOF
-if gmcs try-copy.cs -r:Mono.Posix.dll 2>/dev/null >/dev/null ; then
+if mcs try-copy.cs -r:Mono.Posix.dll 2>/dev/null >/dev/null ; then
 	AC_MSG_RESULT([yes])
 	HAVE_MONO_UNIX_NATIVE_COPY_FLOCK=1
 else
@@ -176,4 +176,3 @@ echo "   * Installation prefix = $prefix"
 echo "   * C# compiler = $CSC"
 echo "   * NUnit support: $enable_nunit"
 echo ""
-

--- a/doc/en/Mono.Fuse/FileSystem.xml
+++ b/doc/en/Mono.Fuse/FileSystem.xml
@@ -120,7 +120,7 @@ class SimpleFS : FileSystem {
   }
 }</code>
       <para>The above program can be compiled as:</para>
-      <code lang="sh">gmcs -r:Mono.Fuse.dll -r:Mono.Posix.dll SimpleFS.cs</code>
+      <code lang="sh">mcs -r:Mono.Fuse.dll -r:Mono.Posix.dll SimpleFS.cs</code>
       <para>
       The resulting program can then be used by executing it and using
       normal shell programs to interact with it.


### PR DESCRIPTION
Greatings, 

I know this project seems to have been dormant for a while, but I was hoping to use it for a personal project. It seems that when I tried to build with modern mono (4.2.3.0) installed, the auto configure scripts failed when trying to find gmcs.  It seems that Mono 4 no longer supports gmcs for building. 

This is a naive refactor to use mcs for compiling C# files. It seems to work for me. I was hoping to see if I'm on the right path here :-)

--Justin
